### PR TITLE
Hopefully fix conn leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
+      <version>2.5.1</version>
     </dependency>
     <!-- Add H2 database support [for running with local profile] -->
     <dependency>


### PR DESCRIPTION
I'm having kind of a hard time verifying for certain but this patch
seems to fix the connection leak issue everyone's been freaking out
about. Basically it updates Hikari to a version that seems to not have
the issue anymore, unless the version Maven was implicitly bundling
before was the same as this (my Java-fu is admittedly lacking, so I'm
having a hard time knowing for certain). At any rate I figure it's worth
giving the patch a go for the next day and seeing if the teams continue
to hit issues or not.